### PR TITLE
Remove extra whitespace from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,20 +47,20 @@ Include the Typelizer DSL in your serializers:
 
 ```ruby
 class ApplicationResource
-  include Alba::Resource 
+  include Alba::Resource
   include Typelizer::DSL
 end
 
 class PostResource < ApplicationResource
   attributes :id, :title, :body
-  
+
   has_one :author, serializer: AuthorResource
 end
 
 class AuthorResource < ApplicationResource
   # specify the model to infer types from (optional)
   typelize_from User
-  
+
   attributes :id, :name
 end
 ```


### PR DESCRIPTION
This change removes some extra spaces from README.md.

(This is probably a tiny positive change, but my actual motivation for submitting this PR is primarily that I am seeing an error (`TypeError: no implicit conversion of nil into String`) when running the specs locally, and also when running the specs in GitHub Actions on my fork ([link](https://github.com/davidrunger/typelizer/actions/runs/10521712372/job/29152884656#step:5:12)), and I want to confirm that those errors will also occur here in this repo's GitHub Actions (and for others locally), as well, and, if so, open a discussion here about how to fix those errors.)