### PR TITLE
Rescue all error classes in TracePoint block

### DIFF
--- a/lib/typelizer/generator.rb
+++ b/lib/typelizer/generator.rb
@@ -44,7 +44,7 @@ module Typelizer
         trace = TracePoint.new(:call) do |tp|
           begin
             next unless tp.self.respond_to?(:typelizer_interface) && !tp.self.send(:respond_to_missing?, :typelizer_interface, false)
-          rescue WeakRef::RefError
+          rescue
             next
           end
           serializer_plugin = tp.self.typelizer_interface.serializer_plugin


### PR DESCRIPTION
fixes https://github.com/skryukov/typelizer/issues/1

Also fixes the error mentioned here (currently occurring on `main`): https://github.com/skryukov/typelizer/pull/2#issue-2482521443