### PR TITLE
Prevent errors with `meta nil`

### DIFF
--- a/lib/typelizer/serializer_plugins/alba.rb
+++ b/lib/typelizer/serializer_plugins/alba.rb
@@ -41,6 +41,8 @@ module Typelizer
         return nil unless serializer._meta
 
         name = serializer._meta.first
+        return nil unless name
+
         [
           build_property(name, name)
         ]


### PR DESCRIPTION
When running typelizer in our project, it fails with `meta nil`. It's described in https://github.com/okuramasafumi/alba?tab=readme-ov-file#metadata so it's a valid usage. `meta_fields` now returns early with `meta nil` to prevent errors.