### PR TITLE
Introduce `Typelizer::ModelPlugins::Auto`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning].
 
 ## [Unreleased]
 
+## Added
+
+- PORO model plugin ([@okuramasafumi])
+- Auto model plugin ([@skryukov])
+
 ## [0.1.3] - 2024-09-27
 
 ## Added

--- a/README.md
+++ b/README.md
@@ -202,8 +202,8 @@ Typelizer.configure do |config|
   # Custom transformation for generated properties
   config.properties_transformer = ->(properties) { ... }
 
-  # Plugin for model type inference (default: ModelPlugins::ActiveRecord)
-  config.model_plugin = Typelizer::ModelPlugins::ActiveRecord
+  # Plugin for model type inference (default: ModelPlugins::Auto)
+  config.model_plugin = Typelizer::ModelPlugins::Auto
 
   # Plugin for serializer parsing (default: SerializerPlugins::Auto)
   config.serializer_plugin = Typelizer::SerializerPlugins::Auto

--- a/lib/typelizer.rb
+++ b/lib/typelizer.rb
@@ -17,6 +17,7 @@ require_relative "typelizer/serializer_plugins/ams"
 
 require_relative "typelizer/model_plugins/active_record"
 require_relative "typelizer/model_plugins/poro"
+require_relative "typelizer/model_plugins/auto"
 
 require_relative "typelizer/railtie" if defined?(Rails)
 

--- a/lib/typelizer/config.rb
+++ b/lib/typelizer/config.rb
@@ -39,7 +39,7 @@ module Typelizer
             Object.const_get(base_class) if Object.const_defined?(base_class)
           end,
 
-          model_plugin: ModelPlugins::ActiveRecord,
+          model_plugin: ModelPlugins::Auto,
           serializer_plugin: SerializerPlugins::Auto,
           plugin_configs: {},
 

--- a/lib/typelizer/model_plugins/auto.rb
+++ b/lib/typelizer/model_plugins/auto.rb
@@ -1,0 +1,19 @@
+module Typelizer
+  module ModelPlugins
+    module Auto
+      class << self
+        def new(model_class:, config:)
+          plugin(model_class).new(model_class: model_class, config: config)
+        end
+
+        def plugin(model_class)
+          if model_class && model_class < ::ActiveRecord::Base
+            ActiveRecord
+          else
+            Poro
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/app/app/serializers/alba/poro_serializer.rb
+++ b/spec/app/app/serializers/alba/poro_serializer.rb
@@ -3,12 +3,7 @@ module Alba
     include Alba::Serializer
     include Typelizer::DSL
 
-    typelize_from :poro
-
-    typelizer_config do |c|
-      # This is required
-      c.model_plugin = Typelizer::ModelPlugins::Poro
-    end
+    typelize_from Poro
 
     attributes :foo, bar: :String
   end


### PR DESCRIPTION
This PR introduces `Typelizer::ModelPlugins::Auto`, which helps Typelizer to decide if it's possible to use `ModelPlugins::ActiveRecord`.