### PR TITLE
Check before overriding dirs config in Railtie initializer

### DIFF
--- a/lib/typelizer/railtie.rb
+++ b/lib/typelizer/railtie.rb
@@ -6,10 +6,12 @@ module Typelizer
 
     initializer "typelizer.configure" do
       Typelizer.configure do |c|
-        c.dirs = [
-          Rails.root.join("app", "resources"),
-          Rails.root.join("app", "serializers")
-        ]
+        if c.dirs.empty?
+          c.dirs = [
+            Rails.root.join("app", "resources"),
+            Rails.root.join("app", "serializers")
+          ]
+        end
       end
     end
 


### PR DESCRIPTION
This PR addresses an issue we found when trying to add this gem to our rails application.

Our monolithic has a componentization setup, so we're using a custom director for our resources to live.

When you try and configure directors in an initializer they're overridden by the rails tie, then Ruby will crash as `initializer "typelizer.generate"` raise an expectation as there are no resources found to generate in the override configuration.

Just checking the config to see if it's already defined solves the problem.