### PR TITLE
Support alba transform keys in the type generation

### DIFF
--- a/lib/typelizer/serializer_plugins/alba.rb
+++ b/lib/typelizer/serializer_plugins/alba.rb
@@ -27,8 +27,8 @@ module Typelizer
         [
           :association, :one, :has_one,
           :many, :has_many,
-          :attributes, :attribute
-          :nested_attribute, :nested
+          :attributes, :attribute,
+          :nested_attribute, :nested,
           :meta
         ]
       end

--- a/lib/typelizer/serializer_plugins/alba.rb
+++ b/lib/typelizer/serializer_plugins/alba.rb
@@ -13,10 +13,10 @@ module Typelizer
 
       def properties
         serializer._attributes.map do |name, attr|
-          if has_transform_key?(serializer)
-            key = fetch_key(serializer, name)
+          key = if has_transform_key?(serializer)
+            fetch_key(serializer, name)
           else
-            key = name
+            name
           end
 
           build_property(key, attr)
@@ -24,24 +24,24 @@ module Typelizer
       end
 
       def methods_to_typelize
-        [
-          :association, :one, :has_one,
-          :many, :has_many,
-          :attributes, :attribute,
-          :nested_attribute, :nested,
-          :meta
+        %i[
+          association one has_one
+          many has_many
+          attributes attribute
+          nested_attribute nested
+          meta
         ]
       end
 
       def typelize_method_transform(method:, name:, binding:, type:, attrs:)
-        return {name => [type, attrs.merge(multi: true)]} if [:many, :has_many].include?(method)
+        return {name => [type, attrs.merge(multi: true)]} if %i[many has_many].include?(method)
 
         super
       end
 
       def root_key
         root = serializer.new({}).send(:_key)
-        if has_transform_key?(serializer) && should_transform_root_key?(serializer)
+        if !root.nil? && has_transform_key?(serializer) && should_transform_root_key?(serializer)
           fetch_key(serializer, root)
         else
           root

--- a/lib/typelizer/serializer_plugins/alba.rb
+++ b/lib/typelizer/serializer_plugins/alba.rb
@@ -24,17 +24,17 @@ module Typelizer
       end
 
       def methods_to_typelize
-        %i[
-          association one has_one
-          many has_many
-          attributes attribute
-          nested_attribute nested
-          meta
+        [
+          :association, :one, :has_one,
+          :many, :has_many,
+          :attributes, :attribute
+          :nested_attribute, :nested
+          :meta
         ]
       end
 
       def typelize_method_transform(method:, name:, binding:, type:, attrs:)
-        return {name => [type, attrs.merge(multi: true)]} if %i[many has_many].include?(method)
+        return {name => [type, attrs.merge(multi: true)]} if [:many, :has_many].include?(method)
 
         super
       end


### PR DESCRIPTION
Hey! I ran into an issue when trying to get typelizer up and running on an exciting project.

Currently, the Alba serializer plugin doesn't support `transform_keys` attribute ([Alba doc link](https://github.com/okuramasafumi/alba?tab=readme-ov-file#key-transformation)). This update uses Alba's key transform method to use the specified transform type if present for both the root key and attributes.

Example: 

Ruby Resource
```ruby
class AdminResource
  include Alba::Resource
  include Typelizer::DSL
  
  attributes full_name: [String, true]
  
  transform_keys :lower_camel
end
```

Generated TS output
```ts
// Typelizer digest ebf32772afe4c2bbf03066005cc6884e
//
// DO NOT MODIFY: This file was automatically generated by Typelizer.

type Admin = {
  fullName: string;
}

export default Admin;
```