### PR TITLE
Create a new rake task to support refreshing all generated types

### DIFF
--- a/lib/tasks/generate.rake
+++ b/lib/tasks/generate.rake
@@ -1,6 +1,19 @@
 namespace :typelizer do
   desc "Generate TypeScript interfaces from serializers"
   task generate: :environment do
+    benchmark do
+      Typelizer::Generator.call
+    end
+  end
+
+  desc "Removes all files in output folder and refreshs all generate TypeScript interfaces from serializers"
+  task "generate:refresh": :environment do
+    benchmark do
+      Typelizer::Generator.call(force: true)
+    end
+  end
+
+  def benchmark(&block)
     require "benchmark"
 
     ENV["TYPELIZER"] = "true"
@@ -8,7 +21,7 @@ namespace :typelizer do
     puts "Generating TypeScript interfaces..."
     serializers = []
     time = Benchmark.realtime do
-      serializers = Typelizer::Generator.call
+      serializers = block.call
     end
 
     puts "Finished in #{time} seconds"

--- a/lib/typelizer/generator.rb
+++ b/lib/typelizer/generator.rb
@@ -2,8 +2,8 @@
 
 module Typelizer
   class Generator
-    def self.call(**)
-      new.call(**)
+    def self.call(**args)
+      new.call(**args)
     end
 
     def initialize(config = Typelizer::Config)

--- a/lib/typelizer/generator.rb
+++ b/lib/typelizer/generator.rb
@@ -2,8 +2,8 @@
 
 module Typelizer
   class Generator
-    def self.call
-      new.call
+    def self.call(**)
+      new.call(**)
     end
 
     def initialize(config = Typelizer::Config)


### PR DESCRIPTION
Hey @skryukov, me again!

When working on the gem and getting it bootstrapped in my project, I wanted an easy way just to regenerate all the types fresh.

I added a rake task that uses the force functionality already added to the generator to refresh the types in a project quickly. 