### PR TITLE
feat(env): Allow disabling Typelizer with Rails development

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,10 @@ When [Listen](https://github.com/guard/listen) is installed, Typelizer automatic
 Typelizer.listen = false
 ```
 
+### Disabling Typelizer
+
+Sometimes we want to use Typelizer only with manual generation. To disable Typelizer during development, we can set `DISABLE_TYPELIZER` environment variable to true. This doesn't affect manual generation.
+
 ## Configuration
 
 ### Global Configuration

--- a/lib/tasks/generate.rake
+++ b/lib/tasks/generate.rake
@@ -3,7 +3,7 @@ namespace :typelizer do
   task generate: :environment do
     require "benchmark"
 
-    ENV["TYPELIZER"] = "true"
+    ENV["DISABLE_TYPELIZER"] = "false"
 
     puts "Generating TypeScript interfaces..."
     serializers = []

--- a/lib/typelizer.rb
+++ b/lib/typelizer.rb
@@ -26,7 +26,9 @@ require "logger"
 module Typelizer
   class << self
     def enabled?
-      ENV["RAILS_ENV"] == "development" || ENV["RACK_ENV"] == "development" || ENV["TYPELIZER"] == "true"
+      return false if ENV["DISABLE_TYPELIZER"] == "true" || ENV["DISABLE_TYPELIZER"] == "1"
+
+      ENV["RAILS_ENV"] == "development" || ENV["RACK_ENV"] == "development" || ENV["DISABLE_TYPELIZER"] == "false"
     end
 
     attr_accessor :dirs

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-ENV["TYPELIZER"] = "true"
+ENV["DISABLE_TYPELIZER"] = "false"
 ENV["RAILS_ENV"] = "test"
 require File.expand_path("app/config/environment", __dir__)
 


### PR DESCRIPTION
We faced an issue which is resolved by disabling Typelizer. Disabling was hard when Rails env is development, so this commit changed env name from `TYPELIZER` to `DISABLE_TYPELIZER` and the logic for disabling.
This commit also adds a description of this environment variable to README.