### PR TITLE
Allow to get interfaces without generating typescript files

### DIFF
--- a/lib/typelizer/generator.rb
+++ b/lib/typelizer/generator.rb
@@ -16,12 +16,16 @@ module Typelizer
     def call(force: false)
       return unless Typelizer.enabled?
 
-      read_serializers
-
-      interfaces = target_serializers.map(&:typelizer_interface).reject(&:empty?)
       writer.call(interfaces, force: force)
 
       interfaces
+    end
+
+    def interfaces
+      @interfaces ||= begin
+        read_serializers
+        target_serializers.map(&:typelizer_interface).reject(&:empty?)
+      end
     end
 
     private


### PR DESCRIPTION
Adds new public method `Typelizer::Generator#interfaces` that allows to get intermediate interface objects without generating result typescript definitions.

Because sometimes one just want to hack with intermediate data without getting files.