### PR TITLE
Define underlying type for enums to be always string

### DIFF
--- a/lib/typelizer/model_plugins/active_record.rb
+++ b/lib/typelizer/model_plugins/active_record.rb
@@ -28,6 +28,7 @@ module Typelizer
         prop.type = @config.type_mapping[column.type]
         prop.comment = comment_for(prop)
         prop.enum = enum_for(prop)
+        prop.type = :string if prop.enum # Ignore underlying column type for enums
 
         prop
       end

--- a/spec/app/app/models/post.rb
+++ b/spec/app/app/models/post.rb
@@ -1,5 +1,5 @@
 class Post < ApplicationRecord
   belongs_to :user
 
-  enum category: [:news, :article, :blog].index_by(&:itself)
+  enum category: { news: 1, article: 2, blog: 3 }
 end

--- a/spec/app/app/models/post.rb
+++ b/spec/app/app/models/post.rb
@@ -1,5 +1,5 @@
 class Post < ApplicationRecord
   belongs_to :user
 
-  enum category: { news: 1, article: 2, blog: 3 }
+  enum category: {news: 1, article: 2, blog: 3}
 end

--- a/spec/app/db/migrate/20240707052907_create_posts.rb
+++ b/spec/app/db/migrate/20240707052907_create_posts.rb
@@ -2,7 +2,7 @@ class CreatePosts < ActiveRecord::Migration[7.1]
   def change
     create_table :posts do |t|
       t.string :title
-      t.string :category
+      t.integer :category
       t.text :body
       t.datetime :published_at
       t.references :user, null: false, foreign_key: true


### PR DESCRIPTION
In case if underlying datatype is integer, enums should be reported as strings (theoretically enums can be other datatypes, but in the wild I've not seen anything but strings)

This doesn't affect generated typescript types now (as they include only enum values and doesn't include type itself), but may affect in the future.