### PR TITLE
fix: generate types on the fly

### DIFF
--- a/lib/typelizer/property.rb
+++ b/lib/typelizer/property.rb
@@ -24,8 +24,10 @@ module Typelizer
     end
 
     def fingerprint
-      props = to_h.merge(type: type_name).reject { |_, v| v.nil? }.map { |k, v| "#{k}=#{v.inspect}" }.join(" ")
-      "<#{self.class.name} #{props}>"
+      props = to_h
+      props[:type] = type_name
+      props = props.filter_map { |k, v| "#{k}=#{v.inspect}" unless v.nil? }
+      "<#{self.class.name} #{props.join(" ")}>"
     end
 
     private


### PR DESCRIPTION
This PR fixes types not being generated on the fly since v0.2.0. It also improves memory consumption & speed of types generation.

Before:
```
Finished in 1.7314969999715686 seconds
Total allocated: 337.42 MB (188537 objects)
326.30 MB  typelizer/lib
```

After:
```
Finished in 0.2834309998434037 seconds
Total allocated: 14.93 MB (160467 objects)
2.03 MB  typelizer/lib
```


Fixes #42 