### PR TITLE
feat: add multi‑writer support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Typelizer
 
-
+[![Gem Version](https://badge.fury.io/rb/typelizer.svg)](https://rubygems.org/gems/typelizer)
 
 Typelizer generates TypeScript types from your Ruby serializers. It supports multiple serializer libraries and a flexible, layered configuration model so you can keep your backend and frontend in sync without hand‑maintaining types.
 
@@ -22,14 +22,16 @@ Typelizer generates TypeScript types from your Ruby serializers. It supports mul
 - [Credits](#credits)
 - [License](#license)
 
----
+<a href="https://evilmartians.com/?utm_source=typelizer&utm_campaign=project_page">
+<img src="https://evilmartians.com/badges/sponsored-by-evil-martians.svg" alt="Built by Evil Martians" width="236" height="54">
+</a>
 
 ## Features
 
 - Automatic TypeScript interface generation
 - Support for multiple serializer libraries (`Alba`, `ActiveModel::Serializer`, `Oj::Serializer`, `Panko::Serializer`)
-- Multiple **writers**: emit several variants (e.g., snake\_case and camelCase) in parallel
 - File watching and automatic regeneration in development
+- Multiple output writers: emit several variants (e.g., snake_case and camelCase) in parallel
 
 ## Installation
 
@@ -360,7 +362,7 @@ end
 
 ### Per-serializer configuration
 
-Use typelizer_config within a serializer class to apply overrides with the highest possible priority. 
+Use `typelizer_config` within a serializer class to apply overrides with the highest possible priority. 
 These settings will supersede any conflicting settings from the active writer, global settings, or library defaults.
 
 ```ruby

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Typelizer
 
-[![Gem Version](https://badge.fury.io/rb/typelizer.svg)](https://rubygems.org/gems/typelizer)
 
-Typelizer is a Ruby gem that automatically generates TypeScript interfaces from your Ruby serializers, bridging the gap between your Ruby backend and TypeScript frontend. It supports multiple serializer libraries and provides a flexible configuration system, making it easier to maintain type consistency across your full-stack application.
+
+Typelizer generates TypeScript types from your Ruby serializers. It supports multiple serializer libraries and a flexible, layered configuration model so you can keep your backend and frontend in sync without hand‑maintaining types.
 
 ## Table of Contents
 
@@ -16,20 +16,19 @@ Typelizer is a Ruby gem that automatically generates TypeScript interfaces from 
   - [Automatic Generation in Development](#automatic-generation-in-development)
   - [Disabling Typelizer](#disabling-typelizer)
 - [Configuration](#configuration)
-  - [Global Configuration](#global-configuration)
-  - [Config Options](#config-options)
+  - [Global Configuration](#simple-configuration)
+  - [Writers (multiple outputs)](#defining-multiple-writers)
   - [Per-Serializer Configuration](#per-serializer-configuration)
 - [Credits](#credits)
 - [License](#license)
 
-<a href="https://evilmartians.com/?utm_source=typelizer&utm_campaign=project_page">
-<img src="https://evilmartians.com/badges/sponsored-by-evil-martians.svg" alt="Built by Evil Martians" width="236" height="54">
-</a>
+---
 
 ## Features
 
 - Automatic TypeScript interface generation
 - Support for multiple serializer libraries (`Alba`, `ActiveModel::Serializer`, `Oj::Serializer`, `Panko::Serializer`)
+- Multiple **writers**: emit several variants (e.g., snake\_case and camelCase) in parallel
 - File watching and automatic regeneration in development
 
 ## Installation
@@ -211,8 +210,6 @@ Sometimes we want to use Typelizer only with manual generation. To disable Typel
 
 ## Configuration
 
-### Global Configuration
-
 Typelizer provides several global configuration options:
 
 ```ruby
@@ -226,13 +223,160 @@ Typelizer.logger = Logger.new($stdout, level: :info)
 Typelizer.listen = nil
 ```
 
-### Config Options
+### Configuration Layers
 
-`Typelizer::Config` offers fine-grained control over the gem's behavior. Here's a list of available options:
+Typelizer uses a hierarchical system to resolve settings. Settings are applied in the following order of precedence, where higher numbers override lower ones:
+
+1.  **Per-Serializer Overrides**: Settings defined using `typelizer_config` directly within a serializer class. This layer has the highest priority.
+2.  **Writer-Specific Settings**: Settings defined within a `config.writer(:name) { ... }` block.
+3.  **Global Settings**: Application-wide settings defined by direct assignment (e.g., `config.comments = true`) within the `Typelizer.configure` block.
+4.  **Library Defaults**: The gem's built-in default values.
+
+
+### Simple Configuration (Single Output)
+
+For most apps, a single output is enough. All settings in an initializer apply to the `:default` writer and also act as a global baseline.
+
+- Settings like `dirs` are considered **Global** and establish a baseline for all writers.
+- Settings like `output_dir` or `comments` configure the implicit **`:default` writer**.
+
+```ruby
+# config/initializers/typelizer.rb
+Typelizer.configure do |config|
+  # This is a GLOBAL SETTING. It applies to ALL writers.
+  config.dirs = [Rails.root.join("app/serializers")]
+
+  # This setting configures the :default writer and ALSO acts as a global setting.
+  config.output_dir = "app/javascript/types/generated"
+  config.comments = true
+end
+```
+
+### Defining Multiple Writers
+
+The multi-writer system allows for the generation of multiple, distinct TypeScript outputs. Each output is managed by a named writer with an isolated configuration.
+
+
+#### Writer Inheritance Rules
+
+- By default, a new writer inherits its base settings from the Global Settings.
+- To inherit from another existing writer, use the `from:` option.
+
+
+**A Note on the :default Writer and Inheritance**
+- You usually do not need to declare `writer(:default)`. The implicit default writer automatically uses your global settings. 
+- Declare `writer(:default)` when you want to apply specific overrides to it that should not be inherited by other new writers. This provides a way to separate your application's global baseline from settings that are truly unique to the default output
+
+#### Example of the distinction:
+```ruby
+Typelizer.configure do |config|
+  # === Global Setting ===
+  # `comments: true` applies to :default and will be inherited by :camel_case.
+  config.comments = true
+
+  # === Default-Writer-Only Setting ===
+  # `prefer_double_quotes: true` applies ONLY to the :default writer.
+  # It is NOT a global setting and will NOT be inherited by :camel_case.
+  config.writer(:default) do |c|
+    c.prefer_double_quotes = true
+  end
+
+  # === New Writer Definition ===
+  config.writer(:camel_case) do |c|
+    c.output_dir = "app/javascript/types/camel_case"
+    # This writer inherits `comments: true` from globals.
+    # It does NOT inherit `prefer_double_quotes: true` from the :default writer's block.
+    # Its `prefer_double_quotes` will be `false` (the library default).
+  end
+end
+```
+
+#### Configuring Writers
+You can define writers either inside the configure block or directly on the Typelizer module.
+
+1. **Inside the configure block**
+
+This is the approach for keeping all configuration centralized.
+
+```ruby
+# config/initializers/typelizer.rb
+Typelizer.configure do |config|
+  # ... global settings ...
+
+  config.writer(:camel_case) do |c|
+    c.output_dir = "app/javascript/types/camel_case"
+    c.properties_transformer = ->(properties) { # ... transform ... }
+  end
+
+  config.writer(:admin, from: :camel_case) do |c|
+    c.output_dir = "app/javascript/types/admin"
+    c.null_strategy = :optional
+  end
+end
+```
+
+2. Top-Level Helper
+
+```ruby
+Typelizer.writer(:admin, from: :default) do |c|
+  c.output_dir = Rails.root.join("app/javascript/types/admin")
+  c.prefer_double_quotes = true
+end
+```
+
+#### Comprehensive Example
+This example configures three distinct outputs, demonstrating all inheritance mechanisms.
+
+```ruby
+# config/initializers/typelizer.rb
+Typelizer.configure do |config|
+  # === 1. Global Settings (Baseline for ALL writers) ===
+  config.comments = true
+  config.dirs = [Rails.root.join("app/serializers")]
+
+  # === 2. The :default writer (snake_case output) ===
+  config.writer(:default) do |c|
+    c.output_dir = "app/javascript/types/snake_case"
+  end
+
+  # === 3. A new :camel_case writer ===
+  # Inherits `comments: true` and `dirs` from the Global Settings.
+  config.writer(:camel_case) do |c|
+    c.output_dir = "app/javascript/types/camel_case"
+    c.properties_transformer = lambda do |properties|
+      properties.map { |prop| prop.with_overrides(name: prop.name.to_s.camelize(:lower)) }
+    end
+  end
+
+  # === 4. An "admin" writer that clones :camel_case ===
+  # Use `from:` to explicitly inherit another writer's complete configuration.
+  config.writer(:admin, from: :camel_case) do |c|
+    c.output_dir = "app/javascript/types/admin"
+    # This writer inherits the properties_transformer from :camel_case.
+    c.null_strategy = :optional
+  end
+end
+```
+
+### Per-serializer configuration
+
+Use typelizer_config within a serializer class to apply overrides with the highest possible priority. 
+These settings will supersede any conflicting settings from the active writer, global settings, or library defaults.
+
+```ruby
+class PostResource < ApplicationResource
+  typelizer_config do |c|
+    c.null_strategy = :nullable_and_optional
+    c.plugin_configs = { alba: { ts_mapper: { "UUID" => { type: :string } } } }
+  end
+end
+```
+
+### Option reference
 
 ```ruby
 Typelizer.configure do |config|
-  # Determines how serializer names are mapped to TypeScript interface names
+  # Name to type mapping for serializer classes
   config.serializer_name_mapper = ->(serializer) { ... }
 
   # Maps serializers to their corresponding model classes
@@ -287,20 +431,6 @@ Typelizer.configure do |config|
   # Support comments in generated TypeScript interfaces (default: false)
   # Will add comments to the generated interfaces
   config.comments = false
-end
-```
-
-### Per-Serializer Configuration
-
-You can also configure Typelizer on a per-serializer basis:
-
-```ruby
-class PostResource < ApplicationResource
-  typelizer_config do |config|
-    config.type_mapping = config.type_mapping.merge(jsonb: "Record<string, undefined>", ... )
-    config.null_strategy = :nullable
-    # ...
-  end
 end
 ```
 

--- a/lib/typelizer.rb
+++ b/lib/typelizer.rb
@@ -1,16 +1,22 @@
 # frozen_string_literal: true
 
 require_relative "typelizer/version"
-require_relative "typelizer/config"
 require_relative "typelizer/property"
+require_relative "typelizer/model_plugins/auto"
+require_relative "typelizer/serializer_plugins/auto"
+
+require_relative "typelizer/config"
+require_relative "typelizer/configuration"
+require_relative "typelizer/serializer_config_layer"
+
+require_relative "typelizer/contexts/writer_context"
+require_relative "typelizer/contexts/scan_context"
 require_relative "typelizer/interface"
 require_relative "typelizer/renderer"
 require_relative "typelizer/writer"
 require_relative "typelizer/generator"
-
 require_relative "typelizer/dsl"
 
-require_relative "typelizer/serializer_plugins/auto"
 require_relative "typelizer/serializer_plugins/oj_serializers"
 require_relative "typelizer/serializer_plugins/alba"
 require_relative "typelizer/serializer_plugins/ams"
@@ -18,30 +24,39 @@ require_relative "typelizer/serializer_plugins/panko"
 
 require_relative "typelizer/model_plugins/active_record"
 require_relative "typelizer/model_plugins/poro"
-require_relative "typelizer/model_plugins/auto"
 
 require_relative "typelizer/railtie" if defined?(Rails)
 
 require "logger"
+require "forwardable"
 
 module Typelizer
   class << self
+    extend Forwardable
+
+    # readers
+    def_delegators :configuration, :dirs, :reject_class, :listen, :writer
+
+    # writers
+    def_delegators :configuration, :dirs=, :reject_class=, :listen=
+
     def enabled?
       return false if ENV["DISABLE_TYPELIZER"] == "true" || ENV["DISABLE_TYPELIZER"] == "1"
 
       ENV["RAILS_ENV"] == "development" || ENV["RACK_ENV"] == "development" || ENV["DISABLE_TYPELIZER"] == "false"
     end
 
-    attr_accessor :dirs
-    attr_accessor :reject_class
     attr_accessor :logger
-    attr_accessor :listen
 
     # @private
     attr_reader :base_classes
 
+    def configuration
+      @configuration ||= Configuration.new
+    end
+
     def configure
-      yield Config
+      yield configuration
     end
 
     private
@@ -50,10 +65,7 @@ module Typelizer
   end
 
   # Set in the Railtie
-  self.dirs = []
-  self.reject_class = ->(serializer:) { false }
   self.logger = Logger.new($stdout, level: :info)
-  self.listen = nil
 
   self.base_classes = Set.new
 end

--- a/lib/typelizer/configuration.rb
+++ b/lib/typelizer/configuration.rb
@@ -1,0 +1,159 @@
+# frozen_string_literal: true
+
+require "set"
+require "pathname"
+
+module Typelizer
+  # Central registry for Typelizer multi-writer configuration
+  #
+  # Responsibilities:
+  # - Holds immutable Config per writer name (always includes :default)
+  # - Maintain flat DSL setters for :default (e.g., config.output_dir = ...)
+  # - Allows defining/updating named writers via writer(:name) { |cfg| ... }
+  # - Check unique output_dir across writers to avoid file conflicts
+  #
+  # Config priorities:
+  # - WriterContext merges in order: library defaults < global_settings < writer < DSL inheritance
+  # - global_settings are only updated by flat setters, not by writer(:default) blocks
+  class Configuration
+    DEFAULT_WRITER_NAME = :default
+
+    attr_accessor :dirs, :reject_class, :listen
+    attr_reader :writers, :global_settings
+
+    def initialize
+      @dirs = []
+      @reject_class = ->(serializer:) { false }
+      @listen = nil
+
+      default = Config.build
+
+      @writers = {DEFAULT_WRITER_NAME => default.freeze}
+      @global_settings = {}
+
+      @writer_output_dirs = {DEFAULT_WRITER_NAME => normalize_path(default.output_dir)}
+      @used_output_dirs = Set.new(@writer_output_dirs.values.compact)
+    end
+
+    # Defines or updates a writer configuration.
+    #
+    # Inherits from the existing writer config (or global_settigns if absent), yields a mutable copy,
+    # then freezes and stores it. output_dir is unique and mandatory
+    # Also accepts "from" argument, which allows us to inherit configuration from any writer
+    def writer(name = DEFAULT_WRITER_NAME, from: nil, &block)
+      writer_name = normalize_writer_name(name)
+
+      # Inherit from existing writer config or from "from" attribute or global (flatt) config
+      base_config =
+        if @writers.key?(writer_name)
+          @writers[writer_name]
+        elsif from && @writers.key?(from.to_sym)
+          @writers[from.to_sym]
+        else
+          Config.build(**@global_settings)
+        end
+
+      mutable_config = base_config.with_overrides
+
+      block&.call(mutable_config)
+
+      # Register output directory for uniqueness checking
+      register_output_dir!(writer_name, mutable_config.output_dir)
+
+      # Store and return frozen configuration
+      @writers[writer_name] = mutable_config.freeze
+    end
+
+    def writer_config(name = DEFAULT_WRITER_NAME)
+      @writers.fetch((name || DEFAULT_WRITER_NAME).to_sym)
+    end
+
+    # Reset writers and keep only `default` writer
+    def reset_writers!
+      @writers.keep_if { |key, _| key == DEFAULT_WRITER_NAME }
+
+      @writer_output_dirs = {
+        DEFAULT_WRITER_NAME => normalize_path(@writers[DEFAULT_WRITER_NAME].output_dir)
+      }
+
+      @used_output_dirs = Set.new(@writer_output_dirs.values.compact)
+    end
+
+    private
+
+    # Setters and readers to Writer(:default) config
+    # Keep the "flat" setters for the :default writer, for example:
+    #   config.output_dir = ...
+    #   config.prefer_double_quotes = true
+    def method_missing(name, *args, &block)
+      name = name.to_s
+      config_key = normalize_method_name(name)
+
+      # Setters
+      if name.end_with?("=") && args.length.positive?
+        return super unless config_attribute?(config_key)
+
+        val = args.first
+        new_default = @writers[DEFAULT_WRITER_NAME].with_overrides(config_key => val)
+
+        register_output_dir!(DEFAULT_WRITER_NAME, new_default.output_dir) if config_key == :output_dir
+
+        @writers[DEFAULT_WRITER_NAME] = new_default.freeze
+
+        return @global_settings[config_key] = val
+      end
+
+      # Readers
+      return @writers[DEFAULT_WRITER_NAME].public_send(config_key) if args.empty? && config_attribute?(config_key)
+
+      super
+    end
+
+    def respond_to_missing?(name, include_private = false)
+      str = name.to_s
+      key = normalize_method_name(str)
+      (config_attribute?(key) && (str.end_with?("=") || true)) || super
+    end
+
+    # Normalizes and validates writer name
+    def normalize_writer_name(name)
+      writer_name = (name || DEFAULT_WRITER_NAME).to_sym
+
+      raise ArgumentError, "Writer name cannot be empty" if writer_name.to_s.strip.empty?
+
+      writer_name
+    end
+
+    # Validates and registers output directory for uniqueness across writers
+    def register_output_dir!(writer_name, dir)
+      raise ArgumentError, "output_dir must be configured for writer :#{writer_name}" if dir.to_s.strip.empty?
+
+      path = normalize_path(dir)
+
+      current = @writer_output_dirs[writer_name]
+      return if current == path
+
+      if @writer_output_dirs.any? { |k, v| k != writer_name && v == path }
+        holder = @writer_output_dirs.key(path)
+
+        raise ArgumentError, "output_dir '#{path}' is already in use by writer :#{holder}"
+      end
+
+      @used_output_dirs.delete(current) if current
+      @writer_output_dirs[writer_name] = path
+      @used_output_dirs << path
+    end
+
+    def normalize_path(dir)
+      Pathname(dir).expand_path.to_s
+    end
+
+    def normalize_method_name(name)
+      name.to_s.chomp("=").to_sym
+    end
+
+    def config_attribute?(name)
+      Config.members.include?(name)
+    end
+  end
+end

--- a/lib/typelizer/contexts/scan_context.rb
+++ b/lib/typelizer/contexts/scan_context.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Typelizer
+  # Builds a minimal plugin used during scan time
+  class ScanContext
+    class InvalidOperationError < StandardError; end
+
+    # Interface creation is not available during DSL scanning phase (TracePoint)
+    def self.interface_for(serializer_class)
+      class_name = serializer_class&.name || "unknown class"
+      raise InvalidOperationError,
+        "Interface creation is not allowed during DSL scan (#{class_name})"
+    end
+
+    # just in case, if we call ScanContext like an object
+    def interface_for(serializer_class)
+      self.class.interface_for(serializer_class)
+    end
+  end
+end

--- a/lib/typelizer/contexts/writer_context.rb
+++ b/lib/typelizer/contexts/writer_context.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+module Typelizer
+  # Context for a single writer during a generation pass.
+  # - Caches one Interface per serializer class (prevents duplicates/loops)
+  # - Computes per-serializer effective Config:
+  #   library defaults < global (flat setters) < writer < DSL (parent → child)
+  class WriterContext
+    attr_reader :writer_config, :writer_name
+
+    def initialize(writer_name: :default, configuration: Typelizer.configuration)
+      @configuration = configuration
+      @writer_name = (writer_name || :default).to_sym
+      @writer_config = configuration.writer_config(@writer_name)
+
+      @interface_cache = {}
+      @config_cache = {}
+      @dsl_cache = {}
+    end
+
+    # Returns a memoized Interface for the given serializer class within this writer context
+    # Guarantees a single Interface instance per serializer (in this context), which:
+    # - preserves object identity across associations,
+    # - prevents infinite loops on cyclic relations,
+    # - and avoids redundant recomputation
+    # The cache is scoped to WriterContext (i.e., per writer and per generation run)
+    def interface_for(serializer_class)
+      raise ArgumentError, "Serializer class cannot be nil" if serializer_class.nil?
+
+      @interface_cache[serializer_class] ||= Interface.new(
+        serializer: serializer_class,
+        context: self
+      )
+    end
+
+    # Resolves the effective configuration for a serializer class by merging
+    # configuration layers in priority order:
+    #  Library defaults
+    #  Global configuration settings
+    #  Writer-specific configuration
+    #  DSL configuration with inheritance (highest priority)
+    def config_for(serializer_class)
+      raise ArgumentError, "Serializer class cannot be nil" unless serializer_class
+
+      @config_cache[serializer_class] ||= build_config(serializer_class)
+    end
+
+    private
+
+    # Builds the correct configuration by merging all configuration layers
+    def build_config(serializer_class)
+      global_settings = @configuration.global_settings
+      writer_settings = @writer_config.to_h
+      dsl_settings = dsl_config_for(serializer_class)
+
+      # Merge in priority order: global < writer < DSL
+      merged_config = deep_merge(global_settings, writer_settings)
+      merged_config = deep_merge(merged_config, dsl_settings)
+
+      Config.build(**merged_config).freeze
+    end
+
+    def dsl_config_for(klass)
+      return @dsl_cache[klass] if @dsl_cache.key?(klass)
+
+      # Recursively get the parent's DSL config. If no parent or parent is not
+      # a Typelizer serializer, the base is an empty hash.
+      parent_dsl = (parent = klass.superclass).respond_to?(:typelizer_config) ? dsl_config_for(parent) : {}
+
+      # Get this class's own local overrides.
+      local_dsl = klass.respond_to?(:typelizer_config) ? klass.typelizer_config.to_h : {}
+
+      @dsl_cache[klass] = deep_merge(parent_dsl, local_dsl).freeze
+    end
+
+    def deep_merge(hash_one, hash_two)
+      # If Active Support's `deep_merge` exists, use it
+      return hash_one.deep_merge(hash_two) if hash_one.respond_to?(:deep_merge)
+
+      return hash_one if hash_one == hash_two
+      return hash_one if hash_two.empty?
+      return hash_two if hash_one.empty?
+
+      hash_one.merge(hash_two) do |_, old_v, new_v|
+        (old_v.is_a?(Hash) && new_v.is_a?(Hash)) ? deep_merge(old_v, new_v) : new_v
+      end
+    end
+  end
+end

--- a/lib/typelizer/contexts/writer_context.rb
+++ b/lib/typelizer/contexts/writer_context.rb
@@ -8,9 +8,9 @@ module Typelizer
   class WriterContext
     attr_reader :writer_config, :writer_name
 
-    def initialize(writer_name: :default, configuration: Typelizer.configuration)
+    def initialize(writer_name: nil, configuration: Typelizer.configuration)
       @configuration = configuration
-      @writer_name = (writer_name || :default).to_sym
+      @writer_name = (writer_name || Configuration::DEFAULT_WRITER_NAME).to_sym
       @writer_config = configuration.writer_config(@writer_name)
 
       @interface_cache = {}

--- a/lib/typelizer/property.rb
+++ b/lib/typelizer/property.rb
@@ -26,8 +26,9 @@ module Typelizer
     def fingerprint
       props = to_h
       props[:type] = type_name
-      props = props.filter_map { |k, v| "#{k}=#{v.inspect}" unless v.nil? }
-      "<#{self.class.name} #{props.join(" ")}>"
+      props.each_with_object(+"<#{self.class.name}") do |(k, v), fp|
+        fp << " #{k}=#{v.inspect}" unless v.nil?
+      end << ">"
     end
 
     private

--- a/lib/typelizer/serializer_config_layer.rb
+++ b/lib/typelizer/serializer_config_layer.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module Typelizer
+  # SerializerConfigLayer
+  #
+  # Lightweight, validated container for per-serializer overrides defined via the DSL.
+  #
+  # - Backed by a plain Hash for cheap deep-merge later (see WriterContext).
+  # - Only keys from Config.members are allowed; unknown keys raise NoMethodError.
+  # - Supports flat setters/getters in the DSL (e.g., c.null_strategy = :nullable_and_optional).
+  # - Mutable only via the DSL; #to_h returns a frozen hash to prevent external mutation.
+  #
+  # Rationale: we don't allocate another Config here; this layer is merged on top of
+  # library/global/writer settings when computing the effective config.
+  class SerializerConfigLayer
+    VALID_KEYS = Config.members.to_set
+
+    def initialize(target_hash)
+      @target_hash = target_hash
+    end
+
+    def to_h
+      @target_hash.dup.freeze
+    end
+
+    private
+
+    def method_missing(name, *args)
+      name = name.to_s
+      key = name.chomp("=").to_sym
+
+      raise NoMethodError, "Unknown configuration key: '#{key}'" unless VALID_KEYS.include?(key)
+
+      return @target_hash[key] = args.first if name.end_with?("=") && args.length == 1
+
+      return @target_hash[key] if args.empty?
+
+      super
+    end
+
+    def respond_to_missing?(name, include_private = false)
+      VALID_KEYS.include?(name.to_s.chomp("=").to_sym) || super
+    end
+  end
+end

--- a/lib/typelizer/serializer_plugins/alba.rb
+++ b/lib/typelizer/serializer_plugins/alba.rb
@@ -92,9 +92,10 @@ module Typelizer
           )
         when ::Alba::Association
           resource = attr.instance_variable_get(:@resource)
+
           Property.new(
             name: name,
-            type: Interface.new(serializer: resource),
+            type: context.interface_for(resource),
             optional: false,
             nullable: false,
             multi: false, # we override this in typelize_method_transform

--- a/lib/typelizer/serializer_plugins/ams.rb
+++ b/lib/typelizer/serializer_plugins/ams.rb
@@ -18,7 +18,7 @@ module Typelizer
 
       def properties
         serializer._attributes_data.merge(serializer._reflections).flat_map do |key, association|
-          type = association.options[:serializer] ? Interface.new(serializer: association.options[:serializer]) : nil
+          type = association.options[:serializer] ? context.interface_for(association.options[:serializer]) : nil
           adapter = ActiveModelSerializers::Adapter.configured_adapter
           Property.new(
             name: adapter.transform_key_casing!(key.to_s, association.options),

--- a/lib/typelizer/serializer_plugins/auto.rb
+++ b/lib/typelizer/serializer_plugins/auto.rb
@@ -2,8 +2,8 @@ module Typelizer
   module SerializerPlugins
     module Auto
       class << self
-        def new(serializer:, config:)
-          plugin(serializer).new(serializer: serializer, config: config)
+        def new(serializer:, config:, context:)
+          plugin(serializer).new(serializer: serializer, config: config, context: context)
         end
 
         def plugin(serializer)

--- a/lib/typelizer/serializer_plugins/base.rb
+++ b/lib/typelizer/serializer_plugins/base.rb
@@ -1,9 +1,10 @@
 module Typelizer
   module SerializerPlugins
     class Base
-      def initialize(serializer:, config:)
+      def initialize(serializer:, config:, context:)
         @serializer = serializer
         @config = config
+        @context = context
       end
 
       def root_key
@@ -28,7 +29,7 @@ module Typelizer
 
       private
 
-      attr_reader :serializer, :config
+      attr_reader :serializer, :config, :context
     end
   end
 end

--- a/lib/typelizer/serializer_plugins/oj_serializers.rb
+++ b/lib/typelizer/serializer_plugins/oj_serializers.rb
@@ -18,9 +18,9 @@ module Typelizer
         attributes
           .flat_map do |key, options|
             if options[:association] == :flat
-              Interface.new(serializer: options.fetch(:serializer)).properties
+              context.interface_for(options.fetch(:serializer)).properties
             else
-              type = options[:serializer] ? Interface.new(serializer: options[:serializer]) : options[:type]
+              type = options[:serializer] ? context.interface_for(options[:serializer]) : options[:type]
               Property.new(
                 name: key,
                 type: type,

--- a/lib/typelizer/serializer_plugins/panko.rb
+++ b/lib/typelizer/serializer_plugins/panko.rb
@@ -48,7 +48,7 @@ module Typelizer
       def association_property(assoc, multi: false)
         key = assoc.name_str
         serializer = assoc.descriptor.type
-        type = serializer ? Interface.new(serializer: serializer) : nil
+        type = serializer ? context.interface_for(serializer) : nil
         Property.new(
           name: key,
           type: type,

--- a/spec/typelizer/configuration_spec.rb
+++ b/spec/typelizer/configuration_spec.rb
@@ -1,0 +1,189 @@
+# frozen_string_literal: true
+
+RSpec.describe Typelizer::Configuration, type: :typelizer do
+  subject(:config_manager) { configuration }
+
+  let(:configuration) { Typelizer.configuration }
+  let(:default_output_dir) { configuration.writer_config(:default).output_dir }
+  let(:custom_output_dir) { Pathname(default_output_dir).parent.join("custom") }
+
+  def restore_defaults!
+    configuration.reset_writers!
+    configuration.types_import_path = "@/types"
+    configuration.prefer_double_quotes = false
+  end
+
+  around do |ex|
+    restore_defaults!
+    ex.call
+    restore_defaults!
+  end
+
+  describe "#writer" do
+    it "creates and stores a new writer config" do
+      config_manager.writer(:custom) do |c|
+        c.output_dir = custom_output_dir
+        c.comments = true
+      end
+
+      expect(config_manager.writers).to have_key(:custom)
+
+      custom = config_manager.writer_config(:custom)
+      expect(custom).to be_a(Typelizer::Config)
+      expect(custom.output_dir).to eq(custom_output_dir)
+      expect(custom.comments).to be(true)
+      expect(custom).to be_frozen
+    end
+
+    it "does not affect changes in default writer to others" do
+      configuration.comments = false
+
+      config_manager.writer(:default) do |c|
+        c.comments = true
+      end
+
+      config_manager.writer(:custom) do |c|
+        c.output_dir = custom_output_dir
+      end
+
+      custom = config_manager.writer_config(:custom)
+      default = config_manager.writer_config(:default)
+
+      expect(custom.comments).to be(false)
+      expect(default.comments).to be(true)
+    end
+
+    it "rejects blank writer names" do
+      expect { configuration.writer("") }.to raise_error(ArgumentError, /Writer name cannot be empty/)
+    end
+
+    it "requires output_dir for non-default writers" do
+      expect do
+        configuration.writer(:no_dir) { |c|
+          c.comments = true
+          c.output_dir = nil
+        }
+      end.to raise_error(ArgumentError, /output_dir must be configured for writer :no_dir/)
+    end
+
+    it "does not mirror writer(:default) block changes into global_settings" do
+      before_global = configuration.global_settings.dup
+      configuration.writer(:default) { |c| c.prefer_double_quotes = true }
+
+      expect(configuration.global_settings).to eq(before_global)
+    end
+
+    it "raises an error when two writers use the same output_dir" do
+      config_manager.writer(:one) { |c| c.output_dir = custom_output_dir }
+      expect do
+        config_manager.writer(:two) { |c| c.output_dir = custom_output_dir }
+      end.to raise_error(ArgumentError, /already in use by writer :one/)
+    end
+
+    it "allows reusing an output_dir after reset_writers!" do
+      config_manager.writer(:one) { |c| c.output_dir = custom_output_dir }
+      configuration.reset_writers!
+      expect { config_manager.writer(:two) { |c| c.output_dir = custom_output_dir } }.not_to raise_error
+    end
+  end
+
+  describe "writer inheritance via :from" do
+    it "clones settings from an existing writer when :from is provided" do
+      # Tweak :default but DO NOT mirror into globals
+      configuration.writer(:default) { |w| w.prefer_double_quotes = true }
+
+      # Create a new writer explicitly cloning :default
+      configuration.writer(:derived, from: :default) do |w|
+        w.output_dir = custom_output_dir
+      end
+
+      derived = configuration.writer_config(:derived)
+      default = configuration.writer_config(:default)
+
+      expect(derived.prefer_double_quotes).to be(true) # cloned from :default
+      expect(derived.output_dir).to eq(custom_output_dir)
+      expect(default.prefer_double_quotes).to be(true)
+    end
+
+    it "falls back to global flat settings when :from references a non-existent writer" do
+      # Set a global flat setting (affects all future writers)
+      configuration.comments = true
+
+      configuration.writer(:ghost_clone, from: :i_do_not_exist) do |w|
+        w.output_dir = custom_output_dir
+      end
+
+      ghost = configuration.writer_config(:ghost_clone)
+      expect(ghost.comments).to be(true) # inherited from global settings, not from writer(:default)
+    end
+
+    it "does not retroactively change an already created writer if the source writer changes later" do
+      # Base writer
+      configuration.writer(:base) do |w|
+        w.output_dir = custom_output_dir
+        w.prefer_double_quotes = true
+      end
+
+      # Clone from :base at this moment in time
+      other_dir = Pathname(custom_output_dir).parent.join("another")
+      configuration.writer(:clone, from: :base) do |w|
+        w.output_dir = other_dir
+      end
+
+      # Now mutate :base clone must remain as it was at creation time
+      configuration.writer(:base) do |w|
+        w.prefer_double_quotes = false
+      end
+
+      clone = configuration.writer_config(:clone)
+      base = configuration.writer_config(:base)
+
+      expect(clone.prefer_double_quotes).to be(true)
+      expect(base.prefer_double_quotes).to be(false)
+    end
+  end
+
+  describe "flat setters on the configuration root" do
+    it "update the default writer and global_settings consistently" do
+      configuration.types_import_path = "@/my_types"
+      configuration.prefer_double_quotes = true
+
+      default_cfg = configuration.writer_config(:default)
+      expect(default_cfg.types_import_path).to eq("@/my_types")
+      expect(default_cfg.prefer_double_quotes).to be(true)
+
+      expect(configuration.global_settings[:types_import_path]).to eq("@/my_types")
+      expect(configuration.global_settings[:prefer_double_quotes]).to be(true)
+    end
+
+    it "rejects blank or nil output_dir" do
+      expect { configuration.output_dir = "" }.to raise_error(ArgumentError, /must be configured for writer :default/)
+      expect { configuration.output_dir = nil }.to raise_error(ArgumentError, /must be configured for writer :default/)
+    end
+  end
+
+  describe "flat getters on the configuration root" do
+    it "allows read-modify-write for hash attributes like type_mapping" do
+      # get current mapping via flat getter, then merge and assign back
+      current = configuration.type_mapping
+      expect(current).to be_a(Hash)
+
+      configuration.type_mapping = current.merge(float: :number, jsonb: :object)
+
+      updated = configuration.writer_config(:default).type_mapping
+      expect(updated[:float]).to eq(:number)
+      expect(updated[:jsonb]).to eq(:object)
+    end
+  end
+
+  describe "#writer_config" do
+    it "returns the default writer config when no name is given" do
+      expect(config_manager.writer_config).to eq(config_manager.writers[:default])
+    end
+
+    it "returns the requested named writer config when present" do
+      config_manager.writer(:another) { |c| c.output_dir = custom_output_dir }
+      expect(config_manager.writer_config(:another).output_dir).to eq(custom_output_dir)
+    end
+  end
+end

--- a/spec/typelizer/generator_spec.rb
+++ b/spec/typelizer/generator_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+RSpec.describe Typelizer::Generator, type: :typelizer do
+  let(:configuration) { Typelizer.configuration }
+  let(:default_output_dir) { configuration.writer_config(:default).output_dir }
+  let(:camel_case_output_dir) { default_output_dir.parent.join("generator_camel_case") }
+
+  # camelCase transformer for a writer
+  let(:camel_case_transformer) do
+    lambda do |properties|
+      properties.map do |prop|
+        new_name = prop.name.to_s.camelize(:lower)
+        prop.class.new(**prop.to_h.merge(name: new_name))
+      end
+    end
+  end
+
+  def restore_defaults!
+    configuration.reset_writers!
+    configuration.types_import_path = "@/types"
+    configuration.prefer_double_quotes = false
+  end
+
+  around do |ex|
+    restore_defaults!
+    configuration.writer(:camel_case) do |c|
+      c.output_dir = camel_case_output_dir
+      c.properties_transformer = camel_case_transformer
+    end
+
+    ex.call
+
+    restore_defaults!
+
+    FileUtils.rm_rf(camel_case_output_dir)
+  end
+
+  describe "#call" do
+    subject(:generator) { described_class.new }
+
+    it "generates files for all writers and applies writer-specific transformers" do
+      expect { generator.call(force: true) }.not_to raise_error
+
+      expect(default_output_dir).to be_directory
+      expect(camel_case_output_dir).to be_directory
+
+      # Base (snake_case) must keep snake case field names
+      base_post = default_output_dir.join("AlbaPost.ts")
+      expect(base_post).to exist
+      base_content = File.read(base_post)
+      expect(base_content).to include("next_post: Post")
+      expect(base_content).not_to include("nextPost: Post")
+
+      # Camel writer must apply camelCase transform
+      camel_post = camel_case_output_dir.join("AlbaPost.ts")
+      expect(camel_post).to exist
+      camel_content = File.read(camel_post)
+      expect(camel_content).to include("nextPost: Post")
+      expect(camel_content).not_to include("next_post: Post")
+    end
+  end
+end

--- a/spec/typelizer/inheritance_spec.rb
+++ b/spec/typelizer/inheritance_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+RSpec.describe "Typelizer Inheritance", type: :typelizer do
+  let(:configuration) { Typelizer.configuration }
+  let(:default_output_dir) { configuration.writer_config(:default).output_dir }
+  let(:custom_output_dir) { Pathname(default_output_dir).parent.join("custom") }
+
+  def restore_defaults!
+    configuration.reset_writers!
+    configuration.types_import_path = "@/types"
+    configuration.prefer_double_quotes = false
+  end
+
+  around do |ex|
+    restore_defaults!
+
+    ex.call
+
+    restore_defaults!
+  end
+
+  describe "correct config ordering" do
+    it "checks Serializer Config ordering over writer configs for conflicting options" do
+      # Writer sets options that conflict with Serializer
+      configuration.writer(:conflict_writer) do |c|
+        c.output_dir = custom_output_dir
+        c.null_strategy = :optional
+        c.inheritance_strategy = :full
+      end
+
+      ctx = Typelizer::WriterContext.new(writer_name: :conflict_writer)
+
+      # CustomTypeUserSerializer contains
+      # typelizer_config.inheritance_strategy = :inheritance
+      #
+      # And other options by inheritance from BaseSerializer
+      # typelizer_config.null_strategy = :nullable_and_optional
+      cfg = ctx.config_for(Alba::Inherited::CustomTypeUserSerializer)
+
+      # Checking that applied only Serializer configurations
+      expect(cfg.null_strategy).to eq(:nullable_and_optional)
+      expect(cfg.inheritance_strategy).to eq(:inheritance)
+    end
+  end
+end

--- a/spec/typelizer_spec.rb
+++ b/spec/typelizer_spec.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
 RSpec.describe Typelizer do
-  let(:config) { Typelizer::Config }
+  let(:output_dir) { Typelizer::Config.default_output_dir }
 
   around(:each) do |example|
-    FileUtils.rmtree(config.output_dir)
+    FileUtils.rmtree(output_dir)
     example.run
-    FileUtils.rmtree(config.output_dir)
+    FileUtils.rmtree(output_dir)
   end
 
   it "has a rake task available", aggregate_failures: true do
@@ -14,7 +14,7 @@ RSpec.describe Typelizer do
     expect { Rake::Task["typelizer:generate"].invoke }.not_to raise_error
 
     # check all generated files are equal to the snapshots
-    config.output_dir.glob("**/*.ts").each do |file|
+    output_dir.glob("**/*.ts").each do |file|
       expect(file.read).to match_snapshot(file.basename)
     end
   end


### PR DESCRIPTION
### What is the purpose of this pull request?

This pull request introduces a multi-writer architecture to Typelizer, resolving issue #12. It enables the generation of multiple, independent sets of TypeScript interfaces from the same source serializers, for example, to support both `snake_case` and `camelCase` conventions.

To support this functionality, the underlying configuration system has been refactored. The previous singleton-based model has been replaced with an architecture that uses context objects to manage configuration for each output.

### What changes did you make? (overview)

The refactoring is centered around a new architectural pattern that uses explicit context objects to ensure writer configurations are properly isolated and propagated.

**1. Architectural Changes**

* A new `Typelizer::Configuration` class now acts as the central registry for managing all writer definitions and global settings.
* A new `Typelizer::WriterContext` object is introduced. It is a object created for each writer during a generation run. Its responsibilities are:
    * To hold the specific, fully resolved `Config` for its writer.
    * To act as a factory and cache for all `Interface` instances, ensuring that the writer's context is correctly passed down through nested associations and inheritance chains.
* The `Typelizer::Interface` class has been refactored to be **context-aware**. It now receives a `WriterContext` at initialization and uses it to resolve the correct configuration for all computations. 
* The `Typelizer::Generator` has been updated to be a stateless orchestrator that creates a `WriterContext` for each configured writer.
* Serializer plugins (`Alba`, `AMS`, etc.) have been updated to accept the `WriterContext` to ensure correct `Interface` creation for nested associations.

**2. New Configuration API**

A new DSL is introduced within `Typelizer.configure` that provides a clear hierarchy for settings (`Global` < `Writer` < `Per-Serializer`).

* **Global Settings**: Settings assigned directly to the `config` object (e.g., `config.dirs`) act as a baseline for all writers.
* **Writer Definition**: The `config.writer(:name) { ... }` block defines an isolated configuration for a specific output.
* **Explicit Inheritance**: A `from:` option allows a new writer to inherit its base configuration from another existing writer.

**Example Configuration:**

```ruby
# config/initializers/typelizer.rb
Typelizer.configure do |config|
  # Global setting: applies to all writers as a baseline
  config.comments = true

  # Configures the :default writer
  config.writer(:default) do |c|
    c.output_dir = "app/javascript/types/snake_case"
  end

  # Defines a new :camel_case writer, which inherits global settings
  config.writer(:camel_case) do |c|
    c.output_dir = "app/javascript/types/camel_case"
    c.properties_transformer = ->(properties) { # ... transform to camelCase ... }
  end
end