### PR TITLE
Map uuid type to string

### DIFF
--- a/lib/typelizer/config.rb
+++ b/lib/typelizer/config.rb
@@ -7,7 +7,8 @@ module Typelizer
     integer: :number,
     string: :string,
     text: :string,
-    citext: :string
+    citext: :string,
+    uuid: :string
   }.tap do |types|
     types.default = :unknown
   end


### PR DESCRIPTION
Before this change, `uuid` DB type is mapped to `unknown` type in TypeScript. With this change, we map `uuid` to `string`.