### PR TITLE
Fix types_global example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,7 +421,7 @@ Typelizer.configure do |config|
 
   # List of type names that should be considered global in TypeScript
   # (i.e. not prefixed with the import path)
-  config.types_global << %w[Array Date Record File FileList]
+  config.types_global = %w[Array Date Record File FileList]
 
   # Support TypeScript's Verbatim module syntax option (default: false)
   # Will change imports and exports of types from default to support this syntax option


### PR DESCRIPTION
The `types_global` array was made frozen by default.

https://github.com/skryukov/typelizer/blob/9889d8eeec53972eb5d3b55a2e37d6c6354c7c58/lib/typelizer/config.rb#L20

As such the example in the readme where the array is directly appended to no longer works.  One needs to re-assign the value now instead.