### PR TITLE
Fix attribute re-ordering causes unnecessary Git diffs

### DIFF
--- a/lib/typelizer/interface.rb
+++ b/lib/typelizer/interface.rb
@@ -48,14 +48,14 @@ module Typelizer
         props = serializer_plugin.meta_fields || []
         props = infer_types(props, :_typelizer_meta_attributes)
         props = config.properties_transformer.call(props) if config.properties_transformer
-        props
+        props.sort_by { |p| p.name.to_s }
       end
     end
 
     def trait_interfaces
       return [] unless serializer_plugin.respond_to?(:trait_interfaces)
 
-      @trait_interfaces ||= serializer_plugin.trait_interfaces
+      @trait_interfaces ||= serializer_plugin.trait_interfaces.sort_by { |t| t.name.to_s }
     end
 
     def properties
@@ -63,7 +63,7 @@ module Typelizer
         props = serializer_plugin.properties
         props = infer_types(props)
         props = config.properties_transformer.call(props) if config.properties_transformer
-        props
+        props.sort_by { |p| p.name.to_s }
       end
     end
 
@@ -119,7 +119,7 @@ module Typelizer
           prop.with_traits.map { |t| "#{prop.type.name}#{t.to_s.camelize}Trait" }
         end
 
-        (custom_type_imports + serializer_types + trait_imports + Array(parent_interface&.name)).uniq - Array(self_type_name)
+        (custom_type_imports + serializer_types + trait_imports + Array(parent_interface&.name)).uniq.sort - Array(self_type_name)
       end
     end
 

--- a/lib/typelizer/serializer_plugins/alba/trait_interface.rb
+++ b/lib/typelizer/serializer_plugins/alba/trait_interface.rb
@@ -24,7 +24,7 @@ module Typelizer
       def properties
         @properties ||= begin
           props, typelizes = plugin.trait_properties(trait_name)
-          infer_types(props, typelizes)
+          infer_types(props, typelizes).sort_by { |p| p.name.to_s }
         end
       end
 


### PR DESCRIPTION
It seemed like the generated output was not consistently ordered on every generation, which may have caused the issue.

I specifically asked an LLM to apply alphabetical ordering to types and attributes. This is what it came up with. Maybe it helps.

Note: The test suite does not run yet because the snapshots need to be updated first.

potentially closes #68