### PR TITLE
Fix typelize declarations silently dropped in rake tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning].
 
 ## [Unreleased]
 
+### Changed
+
+- [BREAKING] Dropped `DISABLE_TYPELIZER` environment variable support (deprecated since 0.12.0). Use `TYPELIZER=false` instead. ([@skryukov])
+- [BREAKING] Bumped `railties` requirement to `>= 6.1.0` to use the `server` Railtie block for auto-generation. ([@skryukov])
+
 ### Fixed
 
 - `typelize` declarations silently dropped during rake tasks, producing `unknown` for every field. ([#114](https://github.com/skryukov/typelizer/issues/114)) ([@skryukov])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning].
 
 ## [Unreleased]
 
+### Fixed
+
+- `typelize` declarations silently dropped during rake tasks, producing `unknown` for every field. ([#114](https://github.com/skryukov/typelizer/issues/114)) ([@skryukov])
+
 ## [0.12.0] - 2026-03-29
 
 ### Added

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -121,9 +121,8 @@ rails typelizer:generate:refresh
 |---|---|
 | `TYPELIZER=true` | Force-enable Typelizer (overrides environment detection) |
 | `TYPELIZER=false` | Force-disable Typelizer (does not affect manual `rake` tasks) |
-| `DISABLE_TYPELIZER=true` | **Deprecated.** Maps to `TYPELIZER=false` with a warning |
 
-When neither variable is set, Typelizer is enabled in development mode (`RAILS_ENV=development` or `RACK_ENV=development`).
+When neither variable is set, Typelizer is enabled in development mode (detected via `Rails.env.development?` when Rails is loaded, or via `RAILS_ENV=development` / `RACK_ENV=development` otherwise).
 
 ## Full Option Reference {#full-option-reference}
 

--- a/lib/typelizer.rb
+++ b/lib/typelizer.rb
@@ -50,10 +50,7 @@ module Typelizer
     # Is Typelizer active?
     #
     # Precedence: TYPELIZER env var > development? detection
-    # Legacy DISABLE_TYPELIZER is mapped to TYPELIZER with a deprecation warning.
     def enabled?
-      migrate_legacy_env!
-
       val = ENV["TYPELIZER"]
       return val == "true" || val == "1" if val
 
@@ -98,22 +95,6 @@ module Typelizer
       return Rails.env.development? if defined?(Rails) && Rails.respond_to?(:env)
 
       ENV["RAILS_ENV"] == "development" || ENV["RACK_ENV"] == "development"
-    end
-
-    # Maps legacy DISABLE_TYPELIZER to TYPELIZER with a deprecation warning.
-    # Only takes effect if TYPELIZER is not already set.
-    def migrate_legacy_env!
-      return if @legacy_env_migrated
-      @legacy_env_migrated = true
-
-      val = ENV["DISABLE_TYPELIZER"]
-      return unless val
-
-      new_val = (val == "true" || val == "1") ? "false" : "true"
-      logger.warn(
-        "[Typelizer] DISABLE_TYPELIZER is deprecated, use TYPELIZER=#{new_val} instead."
-      )
-      ENV["TYPELIZER"] ||= new_val
     end
 
     def load_serializers

--- a/lib/typelizer.rb
+++ b/lib/typelizer.rb
@@ -95,6 +95,8 @@ module Typelizer
     private
 
     def development?
+      return Rails.env.development? if defined?(Rails) && Rails.respond_to?(:env)
+
       ENV["RAILS_ENV"] == "development" || ENV["RACK_ENV"] == "development"
     end
 

--- a/lib/typelizer/dsl.rb
+++ b/lib/typelizer/dsl.rb
@@ -33,8 +33,6 @@ module Typelizer
 
       # save association of serializer to model
       def typelize_from(model)
-        return unless Typelizer.enabled?
-
         define_singleton_method(:_typelizer_model_name) { model }
       end
 
@@ -82,8 +80,6 @@ module Typelizer
       private
 
       def assign_type_information(attribute_name, attributes)
-        return unless Typelizer.enabled?
-
         attributes.each do |name, attrs|
           next unless name
 
@@ -111,6 +107,16 @@ module Typelizer
           end
         end
       end
+    end
+
+    module Disabled
+      %i[typelize_from typelize typelize_meta].each do |name|
+        define_method(name) { |*, **| }
+      end
+    end
+
+    def self.disable!
+      ClassMethods.prepend(Disabled)
     end
   end
 end

--- a/lib/typelizer/railtie.rb
+++ b/lib/typelizer/railtie.rb
@@ -15,21 +15,23 @@ module Typelizer
       end
     end
 
-    initializer "typelizer.generate" do |app|
+    initializer "typelizer.configure_dsl" do
+      Typelizer::DSL.disable! unless Typelizer.enabled?
+    end
+
+    server do
       next unless Typelizer.enabled?
 
       generator = Typelizer::Generator.new
 
       if Typelizer.listen == true || (Gem.loaded_specs["listen"] && Typelizer.listen != false)
         require_relative "listen"
-        app.config.after_initialize do
-          Typelizer::Listen.call do
-            Rails.application.reloader.reload!
-          end
+        Typelizer::Listen.call do
+          Rails.application.reloader.reload!
         end
       end
 
-      app.config.to_prepare do
+      Rails.application.config.to_prepare do
         generator.call
         RouteGenerator.call
       end

--- a/spec/typelizer/dsl_disabled_spec.rb
+++ b/spec/typelizer/dsl_disabled_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Typelizer::DSL::Disabled do
+  let(:class_methods) do
+    Module.new do
+      include Typelizer::DSL::ClassMethods
+      prepend Typelizer::DSL::Disabled
+    end
+  end
+
+  let(:klass) do
+    mod = class_methods
+    Class.new { extend mod }
+  end
+
+  describe "#typelize_from" do
+    it "does not define _typelizer_model_name" do
+      klass.typelize_from(Object)
+
+      expect(klass.respond_to?(:_typelizer_model_name)).to be false
+    end
+  end
+
+  describe "#typelize" do
+    it "does not record attribute metadata" do
+      klass.typelize(name: :string)
+
+      expect(klass.instance_variable_get(:@_typelizer_attributes)).to be_nil
+    end
+
+    it "does not set keyless_type when called with a positional type" do
+      klass.typelize(:string)
+
+      expect(klass.keyless_type).to be_nil
+    end
+
+    it "accepts the full signature without raising" do
+      expect { klass.typelize(:string, {optional: true}, name: :integer) }.not_to raise_error
+    end
+  end
+
+  describe "#typelize_meta" do
+    it "does not record meta attribute metadata" do
+      klass.typelize_meta(foo: :string)
+
+      expect(klass.instance_variable_get(:@_typelizer_meta_attributes)).to be_nil
+    end
+  end
+end

--- a/spec/typelizer/enabled_spec.rb
+++ b/spec/typelizer/enabled_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Typelizer, ".enabled?" do
+  around do |example|
+    saved_typelizer = ENV.delete("TYPELIZER")
+    saved_rails_env = ENV.delete("RAILS_ENV")
+    example.run
+  ensure
+    ENV["TYPELIZER"] = saved_typelizer if saved_typelizer
+    ENV["RAILS_ENV"] = saved_rails_env if saved_rails_env
+  end
+
+  # Regression: #114 — under rake, ENV["RAILS_ENV"] is nil while Rails.env is set.
+  it "returns true when Rails.env is development, even without ENV[RAILS_ENV]" do
+    allow(Rails).to receive(:env).and_return(double("Rails.env", development?: true))
+
+    expect(Typelizer.enabled?).to be true
+  end
+
+  it "returns false when Rails.env is not development" do
+    allow(Rails).to receive(:env).and_return(double("Rails.env", development?: false))
+
+    expect(Typelizer.enabled?).to be false
+  end
+
+  it "honors TYPELIZER=true over Rails.env" do
+    ENV["TYPELIZER"] = "true"
+    allow(Rails).to receive(:env).and_return(double("Rails.env", development?: false))
+
+    expect(Typelizer.enabled?).to be true
+  end
+
+  it "honors TYPELIZER=false over Rails.env" do
+    ENV["TYPELIZER"] = "false"
+    allow(Rails).to receive(:env).and_return(double("Rails.env", development?: true))
+
+    expect(Typelizer.enabled?).to be false
+  end
+end

--- a/typelizer.gemspec
+++ b/typelizer.gemspec
@@ -26,6 +26,6 @@ Gem::Specification.new do |spec|
   spec.files = Dir["{app,lib}/**/*", "CHANGELOG.md", "LICENSE.txt", "README.md"]
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "railties", ">= 6.0.0"
+  spec.add_dependency "railties", ">= 6.1.0"
   spec.add_dependency "benchmark"
 end


### PR DESCRIPTION
Fixes #114.

`Typelizer.development?` checked `ENV["RAILS_ENV"]`, which is nil under rake. The DSL gate fired at class-load with the wrong answer, silently dropping every `typelize` call. `skip_check: true` only bypassed the Generator — too late.

### Fix:
- `development?` consults `Rails.env` when Rails is loaded.
- `enabled?` is checked once at Railtie boot. When disabled, `Typelizer::DSL::Disabled` is prepended to turn DSL calls into no-ops. No more per-call gate to diverge.

Note: mutating `ENV["TYPELIZER"]` after boot no longer flips DSL behavior mid-run.
