### PR TITLE
Defer type generation to first HTTP request

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,24 @@ rails typelizer:generate
 - [Configuration](https://typelizer.dev/reference/configuration)
 - [Type Mapping](https://typelizer.dev/reference/type-mapping)
 
+## Development
+
+You need PostgreSQL running locally. Then:
+
+```bash
+bundle install
+cd spec/app && RAILS_ENV=test bundle exec rails db:create db:migrate && cd ../..
+bundle exec rspec
+```
+
+The test suite uses a dummy Rails app in `spec/app/` with models, migrations, and serializers for all four supported frameworks (Alba, AMS, OjSerializers, Panko). Linting is done with StandardRB:
+
+```bash
+bundle exec standardrb
+```
+
+`bundle exec rake` runs both the tests and the linter.
+
 ## Credits
 
 Typelizer is inspired by [types_from_serializers](https://github.com/ElMassimo/types_from_serializers), [js-routes](https://github.com/railsware/js-routes), and [Wayfinder](https://github.com/nicholasvansanten/wayfinder).

--- a/lib/typelizer/middleware.rb
+++ b/lib/typelizer/middleware.rb
@@ -35,8 +35,8 @@ module Typelizer
       RouteGenerator.call
       @pending = false
     rescue ActiveRecord::NoDatabaseError,
-           ActiveRecord::ConnectionNotEstablished,
-           ActiveRecord::StatementInvalid => e
+      ActiveRecord::ConnectionNotEstablished,
+      ActiveRecord::StatementInvalid => e
       raise TypeGenerationError, "Typelizer could not generate types: #{e.message}\n" \
         "Fix the database issue, then reload the page."
     end

--- a/lib/typelizer/middleware.rb
+++ b/lib/typelizer/middleware.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 module Typelizer
+  class TypeGenerationError < StandardError; end
+
   class Middleware
     class << self
       attr_accessor :instance
@@ -32,28 +34,11 @@ module Typelizer
       Generator.new.call
       RouteGenerator.call
       @pending = false
-    rescue => e
-      @pending = false # don't retry every request
-      if database_error?(e)
-        Typelizer.logger.warn(
-          "[Typelizer] Skipping type generation: #{e.message}\n" \
-          "Run pending migrations, then: bin/rails typelizer:generate"
-        )
-      else
-        raise
-      end
-    end
-
-    def database_error?(error)
-      case error
-      when ActiveRecord::NoDatabaseError,
-           ActiveRecord::ConnectionNotEstablished
-        true
-      when ActiveRecord::StatementInvalid
-        true
-      else
-        error.class.name.start_with?("PG::")
-      end
+    rescue ActiveRecord::NoDatabaseError,
+           ActiveRecord::ConnectionNotEstablished,
+           ActiveRecord::StatementInvalid => e
+      raise TypeGenerationError, "Typelizer could not generate types: #{e.message}\n" \
+        "Fix the database issue, then reload the page."
     end
   end
 end

--- a/lib/typelizer/middleware.rb
+++ b/lib/typelizer/middleware.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+module Typelizer
+  class Middleware
+    class << self
+      attr_accessor :instance
+    end
+
+    def initialize(app)
+      @app = app
+      @mutex = Mutex.new
+      @pending = true
+      self.class.instance = self
+    end
+
+    def call(env)
+      if @pending
+        @mutex.synchronize do
+          generate! if @pending
+        end
+      end
+      @app.call(env)
+    end
+
+    def mark_pending!
+      @pending = true
+    end
+
+    private
+
+    def generate!
+      Generator.new.call
+      RouteGenerator.call
+      @pending = false
+    rescue => e
+      @pending = false # don't retry every request
+      if database_error?(e)
+        Typelizer.logger.warn(
+          "[Typelizer] Skipping type generation: #{e.message}\n" \
+          "Run pending migrations, then: bin/rails typelizer:generate"
+        )
+      else
+        raise
+      end
+    end
+
+    def database_error?(error)
+      case error
+      when ActiveRecord::NoDatabaseError,
+           ActiveRecord::ConnectionNotEstablished
+        true
+      when ActiveRecord::StatementInvalid
+        true
+      else
+        error.class.name.start_with?("PG::")
+      end
+    end
+  end
+end

--- a/lib/typelizer/model_plugins/active_record.rb
+++ b/lib/typelizer/model_plugins/active_record.rb
@@ -38,6 +38,7 @@ module Typelizer
       def columns_hash
         return nil unless model_class
         return nil if model_class.abstract_class?
+        return nil unless model_class.table_exists?
 
         model_class.columns_hash
       end
@@ -45,6 +46,7 @@ module Typelizer
       def attribute_types
         return nil unless model_class&.respond_to?(:attribute_types)
         return nil if model_class.abstract_class?
+        return nil unless model_class.table_exists?
 
         model_class.attribute_types
       end
@@ -126,6 +128,7 @@ module Typelizer
         return nil unless assoc
 
         target = assoc.klass
+        return nil unless target.table_exists?
         col = target.columns_hash[info[:original].to_s]
         return nil unless col
 

--- a/lib/typelizer/railtie.rb
+++ b/lib/typelizer/railtie.rb
@@ -22,18 +22,18 @@ module Typelizer
     server do
       next unless Typelizer.enabled?
 
-      generator = Typelizer::Generator.new
+      require_relative "middleware"
+      Rails.application.config.app_middleware.use(Typelizer::Middleware)
 
       if Typelizer.listen == true || (Gem.loaded_specs["listen"] && Typelizer.listen != false)
         require_relative "listen"
-        Typelizer::Listen.call do
+        Typelizer::Listen.call(run_on_start: false) do
           Rails.application.reloader.reload!
         end
       end
 
       Rails.application.config.to_prepare do
-        generator.call
-        RouteGenerator.call
+        Typelizer::Middleware.instance&.mark_pending!
       end
     end
   end

--- a/spec/typelizer/middleware_spec.rb
+++ b/spec/typelizer/middleware_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require "typelizer/middleware"
+
+RSpec.describe Typelizer::Middleware do
+  let(:inner_app) { ->(env) { [200, {}, ["OK"]] } }
+  let(:middleware) { described_class.new(inner_app) }
+  let(:env) { {} }
+
+  after do
+    described_class.instance = nil
+  end
+
+  describe "#initialize" do
+    it "sets the class-level instance" do
+      expect(middleware).to eq(described_class.instance)
+    end
+  end
+
+  describe "#call" do
+    it "generates types on first request" do
+      generator = instance_double(Typelizer::Generator)
+      expect(Typelizer::Generator).to receive(:new).and_return(generator)
+      expect(generator).to receive(:call)
+      expect(Typelizer::RouteGenerator).to receive(:call)
+
+      middleware.call(env)
+    end
+
+    it "does not regenerate on subsequent requests" do
+      generator = instance_double(Typelizer::Generator)
+      expect(Typelizer::Generator).to receive(:new).once.and_return(generator)
+      expect(generator).to receive(:call).once
+      expect(Typelizer::RouteGenerator).to receive(:call).once
+
+      middleware.call(env)
+      middleware.call(env)
+    end
+
+    it "always serves the request even if generation fails with a DB error" do
+      expect(Typelizer::Generator).to receive(:new).and_raise(
+        ActiveRecord::NoDatabaseError.new("no db")
+      )
+      expect(Typelizer.logger).to receive(:warn).with(/Skipping type generation/)
+
+      result = middleware.call(env)
+      expect(result).to eq([200, {}, ["OK"]])
+    end
+
+    it "does not retry after a DB error" do
+      expect(Typelizer::Generator).to receive(:new).once.and_raise(
+        ActiveRecord::NoDatabaseError.new("no db")
+      )
+      allow(Typelizer.logger).to receive(:warn)
+
+      middleware.call(env)
+      # Second call should not attempt generation again
+      middleware.call(env)
+    end
+
+    it "re-raises non-database errors" do
+      expect(Typelizer::Generator).to receive(:new).and_raise(
+        RuntimeError.new("bug in serializer")
+      )
+
+      expect { middleware.call(env) }.to raise_error(RuntimeError, "bug in serializer")
+    end
+  end
+
+  describe "#mark_pending!" do
+    it "causes regeneration on the next request" do
+      generator = instance_double(Typelizer::Generator)
+      expect(Typelizer::Generator).to receive(:new).twice.and_return(generator)
+      expect(generator).to receive(:call).twice
+      expect(Typelizer::RouteGenerator).to receive(:call).twice
+
+      middleware.call(env)
+      middleware.mark_pending!
+      middleware.call(env)
+    end
+  end
+end

--- a/spec/typelizer/middleware_spec.rb
+++ b/spec/typelizer/middleware_spec.rb
@@ -37,28 +37,36 @@ RSpec.describe Typelizer::Middleware do
       middleware.call(env)
     end
 
-    it "always serves the request even if generation fails with a DB error" do
+    it "raises TypeGenerationError on DB error" do
       expect(Typelizer::Generator).to receive(:new).and_raise(
         ActiveRecord::NoDatabaseError.new("no db")
       )
-      expect(Typelizer.logger).to receive(:warn).with(/Skipping type generation/)
 
+      expect { middleware.call(env) }.to raise_error(Typelizer::TypeGenerationError, /no db/)
+    end
+
+    it "retries generation on the next request after a DB error" do
+      call_count = 0
+      generator = instance_double(Typelizer::Generator)
+
+      allow(Typelizer::Generator).to receive(:new) do
+        call_count += 1
+        if call_count == 1
+          raise ActiveRecord::NoDatabaseError, "no db"
+        end
+        generator
+      end
+      allow(generator).to receive(:call)
+      allow(Typelizer::RouteGenerator).to receive(:call)
+
+      expect { middleware.call(env) }.to raise_error(Typelizer::TypeGenerationError)
+
+      # Second call retries and succeeds
       result = middleware.call(env)
       expect(result).to eq([200, {}, ["OK"]])
     end
 
-    it "does not retry after a DB error" do
-      expect(Typelizer::Generator).to receive(:new).once.and_raise(
-        ActiveRecord::NoDatabaseError.new("no db")
-      )
-      allow(Typelizer.logger).to receive(:warn)
-
-      middleware.call(env)
-      # Second call should not attempt generation again
-      middleware.call(env)
-    end
-
-    it "re-raises non-database errors" do
+    it "re-raises non-database errors directly" do
       expect(Typelizer::Generator).to receive(:new).and_raise(
         RuntimeError.new("bug in serializer")
       )


### PR DESCRIPTION
Thank you for typelizer - I remember having something similar in CoffeeScript back when backbone.js was a thing. It is definitely the right approach.

I want to propose this change. Basically, typelizer functions around the same area where ActiveRecord works. ActiveRecord very deliberately does not introspect the database at code definition time - because you can't meaningfully load the code then. This allows you to run `bin/rails db:setup` and have access to constants inside ActiveRecord models even without having set up the DB. The current typelizer setup means that if it has been added to the project, but you just haven't run the latest migrations yet - for example, the table is missing but a model is already present - all your workflows explode _including_ running the migration needed to create the table. In other words: the typelizer is nosing about in the database and breaks dev workflows even on an existing checkout, and it shouldn't. Running the migrations should not require setting an environment variable just to bypass it.

So: I tried bringing it more in line with how ActiveRecord does it. All the generation should actually be deferred to the moment when it's actually needed - and if it fails it should not break the app. It should also be possible for the generation to fail "partially". Open to any suggestions/comments how this could be done differently as well.

## Summary

- **Defer type generation from boot to first HTTP request** via `Typelizer::Middleware`, avoiding DB queries during Railtie initialization that can fail when the database is not yet available (e.g. `db:create`, `db:migrate`, asset precompilation in CI)
- **Add `table_exists?` guards** to the ActiveRecord model plugin so missing tables do not crash boot
- **Show an error page when generation fails due to DB issues** — raises `Typelizer::TypeGenerationError` (rendered by Rails' `DebugExceptions` like the pending-migrations page) instead of silently swallowing errors. Generation retries on every request, so fixing the DB and reloading recovers automatically
- **Add Development section to README** with setup and test instructions

## How it works

1. The Railtie's `server` block inserts `Typelizer::Middleware` and registers a `to_prepare` hook that sets a pending flag
2. On the first HTTP request (and after each code reload), the middleware runs type generation inside a mutex
3. If generation fails due to a DB error, `TypeGenerationError` is raised — Rails renders a diagnostic error page. The pending flag stays set so the next request retries
4. If generation succeeds, the flag clears and subsequent requests pass through without overhead

## Test plan

- [ ] `bundle exec rspec` — full suite (326 examples, 0 failures)
- [ ] `bundle exec standardrb` — linting passes
- [ ] Middleware specs cover: first-request generation, no-op on subsequent requests, DB error raises `TypeGenerationError`, retry-then-recovery, non-DB errors re-raised directly, `mark_pending!` triggers regeneration
