### PR TITLE
Allow Procs in routes.include / routes.exclude

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning].
 
 ## [Unreleased]
 
+### Added
+
+- `routes.include` and `routes.exclude` now accept a `Proc` (or any callable responding to `#call`) in addition to `Regexp`. Predicates receive the route-info hash (`:path`, `:name`, `:controller`, `:action`, `:verb`, `:required_parts`, `:optional_parts`) and must return truthy to match. Heterogeneous arrays are supported. Useful when the URL path alone can't disambiguate routes — e.g. multiple feature areas mounted under different subdomain constraints that share paths, or filtering by HTTP verb / helper name.
+
+  ```ruby
+  config.routes.include = ->(r) { r[:controller].to_s.start_with?("admin/") }
+  ```
+
 ## [0.13.0] - 2026-05-01
 
 ### Added

--- a/docs/guides/routes.md
+++ b/docs/guides/routes.md
@@ -216,6 +216,29 @@ end
 
 Both accept a single `Regexp` or an array of patterns. When `include` is set, only matching routes are generated. `exclude` is applied after `include`.
 
+### Filtering with a predicate
+
+`include` and `exclude` also accept a `Proc` (or any object responding to `#call`) in addition to regexes. The predicate receives a route-info hash and must return truthy to match:
+
+```ruby
+Typelizer.configure do |config|
+  config.routes.include = ->(r) { r[:controller].to_s.start_with?("admin/") }
+end
+```
+
+The hash keys available to the predicate are: `:path`, `:name`, `:controller`, `:action`, `:verb`, `:required_parts`, `:optional_parts`.
+
+You can mix predicates and regexes in an array; routes match if any element matches:
+
+```ruby
+config.routes.include = [
+  /^\/sessions/,
+  ->(r) { r[:controller] == "admin/users" }
+]
+```
+
+Use predicates when the URL path doesn't uniquely identify the routes you want — for example, when multiple feature areas are mounted under different subdomain constraints but share URL paths (`foo.example.com/users` and `bar.example.com/users` both have path `/users` but different controllers).
+
 ## Engine Support {#engines}
 
 Mounted Rails engines are included automatically. Route paths include the mount prefix:

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -86,8 +86,8 @@ end
 |---|---|---|---|
 | `enabled` | `Boolean` | `false` | Enable route helper generation |
 | `output_dir` | `String` | Auto-detected | Output directory. Defaults to `{js_root}/routes` |
-| `include` | `Regexp`, `Array` | `nil` | Only generate routes matching these patterns |
-| `exclude` | `Regexp`, `Array` | `nil` | Skip routes matching these patterns |
+| `include` | `Regexp`, `Proc`, `Array` | `nil` | Only generate routes matching these patterns. Procs receive the route-info hash and return truthy to match. See [Filtering Routes](/guides/routes#filtering). |
+| `exclude` | `Regexp`, `Proc`, `Array` | `nil` | Skip routes matching these patterns. Procs receive the route-info hash and return truthy to match. |
 | `camel_case` | `Boolean` | `true` | Convert route keys to camelCase |
 | `format` | `Symbol` | `:ts` | Output format: `:ts` or `:js` |
 

--- a/lib/typelizer/route_generator.rb
+++ b/lib/typelizer/route_generator.rb
@@ -51,14 +51,22 @@ module Typelizer
 
       if config.include
         patterns = Array(config.include)
-        routes = routes.select { |r| patterns.any? { |p| r[:path].match?(p) } }
+        routes = routes.select { |r| patterns.any? { |p| match_route?(r, p) } }
       end
       if config.exclude
         patterns = Array(config.exclude)
-        routes = routes.reject { |r| patterns.any? { |p| r[:path].match?(p) } }
+        routes = routes.reject { |r| patterns.any? { |p| match_route?(r, p) } }
       end
 
       routes
+    end
+
+    def match_route?(route_info, pattern)
+      if pattern.respond_to?(:call)
+        pattern.call(route_info)
+      else
+        route_info[:path].match?(pattern)
+      end
     end
 
     def build_name_lookups(named_routes, path_prefix: "", name_prefix: "")

--- a/spec/typelizer/route_generator_spec.rb
+++ b/spec/typelizer/route_generator_spec.rb
@@ -150,6 +150,97 @@ RSpec.describe Typelizer::RouteGenerator, type: :typelizer do
       expect(output_dir.join("UsersController.ts")).to exist
     end
 
+    context "with callable include/exclude patterns" do
+      it "accepts a single Proc filtering by controller" do
+        route_config.include = ->(r) { r[:controller] == "admin/users" }
+
+        generator.call(force: true)
+
+        expect(output_dir.join("Admin/UsersController.ts")).to exist
+        expect(output_dir.join("UsersController.ts")).not_to exist
+        expect(output_dir.join("PostsController.ts")).not_to exist
+      end
+
+      it "accepts a Lambda filtering by verb" do
+        route_config.include = lambda { |r| r[:verb] == "post" }
+
+        generator.call(force: true)
+
+        # admin/users only has GET/DELETE actions, so no file should be generated
+        expect(output_dir.join("Admin/UsersController.ts")).not_to exist
+        # users#create is POST, so the file exists but only POST routes are inside
+        users = File.read(output_dir.join("UsersController.ts"))
+        expect(users).to include("method: 'post'")
+        expect(users).not_to include("method: 'get'")
+        expect(users).not_to include("method: 'delete'")
+      end
+
+      it "accepts a Method object" do
+        admin_filter = ->(r) { r[:controller].to_s.start_with?("admin/") }
+        route_config.include = admin_filter.method(:call)
+
+        generator.call(force: true)
+
+        expect(output_dir.join("Admin/UsersController.ts")).to exist
+        expect(output_dir.join("UsersController.ts")).not_to exist
+      end
+
+      it "accepts a heterogeneous array of Regexp and Proc" do
+        route_config.include = [
+          /\A\/admin/,
+          ->(r) { r[:controller] == "pages" }
+        ]
+
+        generator.call(force: true)
+
+        expect(output_dir.join("Admin/UsersController.ts")).to exist
+        expect(output_dir.join("PagesController.ts")).to exist
+        expect(output_dir.join("UsersController.ts")).not_to exist
+        expect(output_dir.join("PostsController.ts")).not_to exist
+      end
+
+      it "disambiguates routes that differ by controller (subdomain-style)" do
+        # Both /users (controller: "users") and /admin/users (controller: "admin/users")
+        # exist; a controller-based predicate distinguishes them where a path regex
+        # like %r{/users} would match both.
+        route_config.include = ->(r) { r[:controller].to_s.start_with?("admin/") }
+
+        generator.call(force: true)
+
+        expect(output_dir.join("Admin/UsersController.ts")).to exist
+        expect(output_dir.join("UsersController.ts")).not_to exist
+      end
+
+      it "still accepts a bare Regexp (backwards compat, positive)" do
+        route_config.include = /\A\/admin/
+
+        generator.call(force: true)
+
+        expect(output_dir.join("Admin/UsersController.ts")).to exist
+        expect(output_dir.join("UsersController.ts")).not_to exist
+      end
+
+      it "still accepts an Array of Regexps (backwards compat)" do
+        route_config.include = [/\A\/admin/, /\A\/posts/]
+
+        generator.call(force: true)
+
+        expect(output_dir.join("Admin/UsersController.ts")).to exist
+        expect(output_dir.join("PostsController.ts")).to exist
+        expect(output_dir.join("UsersController.ts")).not_to exist
+      end
+
+      it "applies callable rules to exclude" do
+        route_config.exclude = ->(r) { r[:controller].to_s.start_with?("admin/") }
+
+        generator.call(force: true)
+
+        expect(output_dir.join("Admin/UsersController.ts")).not_to exist
+        expect(output_dir.join("UsersController.ts")).to exist
+        expect(output_dir.join("PostsController.ts")).to exist
+      end
+    end
+
     it "generates mounted engine routes with mount prefix" do
       generator.call(force: true)
 


### PR DESCRIPTION
## Motivation

`routes.include` and `routes.exclude` currently match a `Regexp` (or array of regexes) against `r[:path]`. That breaks down when an application has multiple feature areas mounted under different subdomain constraints that share URL paths:

```ruby
constraints subdomain: "foo" do
  scope module: "foo" do
    resources :users
  end
end

constraints subdomain: "bar" do
  scope module: "bar" do
    resources :users
  end
end
```

Both produce a route with `path == "/users"`, but `controller` is `foo/users` vs `bar/users`. A path regex matches both; nothing in the current API can include only one. Other use cases land in the same gap: filtering by HTTP verb, by helper-name conventions, or by predicates over multiple fields.

## What this PR does

`routes.include` and `routes.exclude` now accept any callable (`Proc`, `Lambda`, `Method`, or custom `#call`-responder) alongside the existing `Regexp` form. Mixed arrays work too. The predicate receives the route-info hash and returns truthy to match.

```ruby
# Existing forms still work, unchanged
config.routes.include = /\A\/admin/
config.routes.include = [/admin/, /api/]

# New: predicate by controller (resolves the foo/bar example above)
config.routes.include = ->(r) { r[:controller].to_s.start_with?("foo/") }

# New: heterogeneous array
config.routes.include = [
  /\A\/sessions/,
  ->(r) { r[:controller] == "admin/users" }
]

# New: combined predicate
config.routes.exclude = ->(r) { r[:verb] == "get" && r[:name].to_s.end_with?("_internal") }
```

Hash keys available to the predicate: `:path`, `:name`, `:controller`, `:action`, `:verb`, `:required_parts`, `:optional_parts`.

## Implementation

A small dispatch helper in `RouteGenerator`:

```ruby
def match_route?(route_info, pattern)
  if pattern.respond_to?(:call)
    pattern.call(route_info)
  else
    route_info[:path].match?(pattern)
  end
end
```

Bare regexes continue to match against `r[:path]` exactly as before, so this is strictly additive and backwards-compatible. No new config attributes; `Array(callable)` already wraps a single callable, so the existing API just gains a new value type.

`respond_to?(:call)` (rather than `is_a?(Proc)`) was chosen so `Method` objects and custom `#call`-responders work too.